### PR TITLE
Active closure of socket upon reconnection

### DIFF
--- a/src/umqtt/simple2.py
+++ b/src/umqtt/simple2.py
@@ -309,8 +309,10 @@ class MQTTClient:
             self._write(b"\xe0\0")
         except (OSError, MQTTException):
             pass
-        self.poller_r.unregister(self.sock)
-        self.poller_w.unregister(self.sock)
+        if self.poller_r:
+            self.poller_r.unregister(self.sock)
+        if self.poller_w:
+            self.poller_w.unregister(self.sock)
         try:
             self.sock.close()
         except OSError:


### PR DESCRIPTION
This PR explicitly calls disconnect() before connect(), and makes sure disconnect() is idempotent and does nos raise exceptions.

At least in ESP32, connection sockets are limited in number (8 or 10) and they pile up if not explicitly closed and/or garbage-collected. Calling connect() a number of times on umqtt.simple or umqtt.simple2 without explicit closure/gc eventually fails.